### PR TITLE
Do not automatically retrieve a user by email

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,12 @@ Plugin::load('ADmad/SocialAuth', ['bootstrap' => true, 'routes' => true]);
 Database
 --------
 
-The plugin expects that you have a users table with at least `email` field
-and a `social_profiles` table. You can run
+This plugin requires a migration to generate a `social_profiles` table, and it
+can be generated via the official Migrations plugin as follows:
 
-```
+```shell
 bin/cake migrations migrate -p ADmad/SocialAuth
 ```
-
-to generate the `social_profiles` tabel using a migration file provided with
-the plugin.
 
 Usage
 -----
@@ -70,7 +67,6 @@ $middleware->add(new \ADmad\SocialAuth\Middleware\SocialAuthMiddleware([
     'finder' => 'all',
     // Fields.
     'fields' => [
-        'email' => 'email',
         'password' => 'password'
     ],
     // Session key to which to write identity record to.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $middleware->add(new \ADmad\SocialAuth\Middleware\SocialAuthMiddleware([
     'sessionKey' => 'Auth.User',
     // The methods in user model which should be called in case of new user.
     // It should return a User entity.
-    'newUserCallback' => 'newUser',
+    'getUserCallback' => 'getUser',
     // SocialConnect Auth service's providers config. https://github.com/SocialConnect/auth/blob/master/README.md
     'serviceConfig' => [
         'provider' => [
@@ -111,14 +111,14 @@ still do so by configuring the middleware with `'requestMethod' => 'GET'`.
 
 Once a user is authenticated through the provider the authenticator gets the user
 profile from the identity provider and using that tries to find the corresponding
-user record using the user model. If no user is found it calls the `newUser` method
+user record using the user model. If no user is found it calls the `getUser` method
 of your user model. The method recieves social profile model entity as argument
 and return an entity for the new user. E.g.
 
 ```php
 // UsersTable.php
 
-public function newUser(EntityInterface $profile) {
+public function getUser(EntityInterface $profile) {
     // Make sure here that all the required fields are actually present
     if (empty($profile->email)) {
         throw new \RuntimeException('Could not find email in social profile.');

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -179,6 +179,9 @@ class SocialAuthMiddleware
         }
 
         $profile = $this->_getProfileEntity($providerName, $identity, $accessToken, $profile ?: null);
+        if ($profile->isDirty()) {
+            $this->_saveProfile($profile);
+        }
 
         if (!$user) {
             $user = $this->_newUser($profile);

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -46,7 +46,7 @@ class SocialAuthMiddleware
             'password' => 'password',
         ],
         'sessionKey' => 'Auth.User',
-        'newUserCallback' => 'newUser',
+        'getUserCallback' => 'getUser',
         'serviceConfig' => [],
     ];
 
@@ -184,7 +184,7 @@ class SocialAuthMiddleware
         }
 
         if (!$user) {
-            $user = $this->_newUser($profile);
+            $user = $this->_getUser($profile);
         }
         $profile->user_id = $user->id;
 
@@ -259,16 +259,16 @@ class SocialAuthMiddleware
     /**
      * Get new user entity.
      *
-     * It dispatches a `SocialConnect.newUser` event. A listener must return
+     * It dispatches a `SocialConnect.getUser` event. A listener must return
      * an entity for new user record.
      *
      * @param \Cake\Datasource\EntityInterface $profile Social profile entity.
      *
      * @return \Cake\Datasource\EntityInterface User entity.
      */
-    protected function _newUser(EntityInterface $profile)
+    protected function _getUser(EntityInterface $profile)
     {
-        $callbackMethod = $this->config('newUserCallback');
+        $callbackMethod = $this->config('getUserCallback');
 
         $user = call_user_func([$this->_userModel, $callbackMethod], $profile);
 

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -184,7 +184,7 @@ class SocialAuthMiddleware
         }
 
         if (!$user) {
-            $user = $this->_getUser($profile);
+            $user = $this->_getUserEntity($profile);
         }
         $profile->user_id = $user->id;
 
@@ -266,7 +266,7 @@ class SocialAuthMiddleware
      *
      * @return \Cake\Datasource\EntityInterface User entity.
      */
-    protected function _getUser(EntityInterface $profile)
+    protected function _getUserEntity(EntityInterface $profile)
     {
         $callbackMethod = $this->config('getUserCallback');
 

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -156,8 +156,8 @@ class SocialAuthMiddleware
             ])
             ->first();
 
-        $finder = $this->config('finder');
         if ($profile) {
+            $finder = $this->config('finder');
             $userId = $profile->user_id;
             $user = $this->_userModel->get($userId);
             $user = $this->_userModel->find($finder)

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -176,12 +176,6 @@ class SocialAuthMiddleware
 
                 return false;
             }
-        } elseif ($identity->email) {
-            $user = $this->_userModel->find($finder)
-                ->where([
-                    $this->_userModel->aliasField($this->config('fields.email')) => $identity->email,
-                ])
-                ->first();
         }
 
         $profile = $this->_getProfileEntity($providerName, $identity, $accessToken, $profile ?: null);


### PR DESCRIPTION
Instead, let the `getUser` callback do the retrieval.

Also rename the `newUser` logic to `getUser` to make this more apparent.