### PR TITLE
Pass entities to event

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,39 @@ In case of authentication failure user is redirected back to login URL with
   a user has been authenticated through provider but your finder has condition
   to not return inactivate user.
 
+### Event Listener
+
+To set up a listener for the `SocialAuth.afterIdentify` event, you can for example
+add this to your `UsersTable::initialize()` method:
+```php
+use Cake\Event\EventManager;
+
+// at the end of the initialize() method
+EventManager::instance()->on('SocialAuth.afterIdentify', [$this, 'updateUser']);
+```
+
+Then create such method in this table class:
+```php
+    /**
+     * @param \Cake\Event\EventInterface $event
+     *
+     * @return \App\Model\Entity\User
+     */
+    public function updateUser(EventInterface $event): User
+    {
+        /** @var \App\Model\Entity\User $user */
+        $user = $event->getData()['user'];
+        /** @var \ADmad\SocialAuth\Model\Entity\SocialProfile $profile */
+        $profile = $event->getData()['profile'];
+
+        // additional mapping operations
+
+        $this->saveOrFail($user);
+
+        return $user;
+    }
+```
+
 Copyright
 ---------
 Copyright 2017-Present ADmad

--- a/README.md
+++ b/README.md
@@ -216,10 +216,10 @@ Then create such method in this table class:
     {
         /** @var \App\Model\Entity\User $user */
         $user = $event->getData()['user'];
-        /** @var \ADmad\SocialAuth\Model\Entity\SocialProfile $profile */
-        $profile = $event->getData()['profile'];
+        
+        // You can access the profile through $user->profile->...
 
-        // additional mapping operations
+        // Additional mapping operations
 
         $this->saveOrFail($user);
 

--- a/README.md
+++ b/README.md
@@ -209,17 +209,15 @@ Then create such method in this table class:
 ```php
     /**
      * @param \Cake\Event\EventInterface $event
-     *
-     * @return \App\Model\Entity\User
+     * @param \Cake\Datasource\EntityInterface $user
+     * @return \Cake\Datasource\EntityInterface
      */
-    public function updateUser(EventInterface $event): User
-    {
-        /** @var \App\Model\Entity\User $user */
-        $user = $event->getData()['user'];
-        
+    public function updateUser(EventInterface $event, $user)
+    {       
         // You can access the profile through $user->profile->...
 
         // Additional mapping operations
+        // $user->last_login = date('Y-m-d H:i:s');
 
         $this->saveOrFail($user);
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,7 @@
 parameters:
-    level: 6
+    level: 8
     checkMissingIterableValueType: false
-    autoload_files:
+    bootstrapFiles:
         - tests/bootstrap.php
+    ignoreErrors:
+        - '#Parameter \#1 \$function of function call_user_func expects callable\(\): mixed, array\(Cake\\ORM\\Table, mixed\) given.#'

--- a/src/Database/Type/SerializedType.php
+++ b/src/Database/Type/SerializedType.php
@@ -21,7 +21,6 @@ class SerializedType extends BaseType
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
-     *
      * @return string|null
      */
     public function toDatabase($value, DriverInterface $driver)
@@ -38,7 +37,6 @@ class SerializedType extends BaseType
      *
      * @param mixed $value The value to convert.
      * @param \Cake\Database\DriverInterface $driver The driver instance to convert with.
-     *
      * @return string|null|array
      */
     public function toPHP($value, DriverInterface $driver)
@@ -55,7 +53,6 @@ class SerializedType extends BaseType
      *
      * @param mixed $value The value being bound.
      * @param \Cake\Database\DriverInterface $driver The driver.
-     *
      * @return int
      */
     public function toStatement($value, DriverInterface $driver)
@@ -71,7 +68,6 @@ class SerializedType extends BaseType
      * Marshalls request data into a serialization compatible structure.
      *
      * @param mixed $value The value to convert.
-     *
      * @return mixed Converted value.
      */
     public function marshal($value)

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -225,7 +225,7 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
 
         $user->unset($config['fields']['password']);
 
-        $event = $this->dispatchEvent(self::EVENT_AFTER_IDENTIFY, ['user' => $user, 'profile' => $profile]);
+        $event = $this->dispatchEvent(self::EVENT_AFTER_IDENTIFY, ['user' => $user]);
         $result = $event->getResult();
         if ($result !== null) {
             $user = $event->getResult();

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -228,14 +228,14 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
 
         $user->unset($config['fields']['password']);
 
-        if (!$config['userEntity']) {
-            $user = $user->toArray();
-        }
-
-        $event = $this->dispatchEvent(self::EVENT_AFTER_IDENTIFY, ['user' => $user]);
+        $event = $this->dispatchEvent(self::EVENT_AFTER_IDENTIFY, ['user' => $user, 'profile' => $profile]);
         $result = $event->getResult();
         if ($result !== null) {
             $user = $event->getResult();
+        }
+
+        if (!$config['userEntity']) {
+            $user = $user->toArray();
         }
 
         $request->getSession()->write($config['sessionKey'], $user);

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -156,7 +156,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The request.
      * @param \Psr\Http\Server\RequestHandlerInterface $handler The request handler.
-     *
      * @return \Psr\Http\Message\ResponseInterface A response.
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -181,7 +180,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      * Handle login action, initiate authentication process.
      *
      * @param \Cake\Http\ServerRequest $request The request.
-     *
      * @return \Cake\Http\Response A response.
      */
     protected function _handleLoginAction(ServerRequest $request): Response
@@ -201,7 +199,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      * Handle callback action.
      *
      * @param \Cake\Http\ServerRequest $request The request.
-     *
      * @return \Cake\Http\Response A response.
      */
     protected function _handleCallbackAction(ServerRequest $request): Response
@@ -263,7 +260,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      *
      * @param string $providerName Provider name.
      * @param \Cake\Http\ServerRequest $request Request instance.
-     *
      * @return \Cake\Datasource\EntityInterface|null
      */
     protected function _getProfile($providerName, ServerRequest $request): ?EntityInterface
@@ -303,7 +299,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      *
      * @param \Cake\Datasource\EntityInterface $profile Social profile entity
      * @param \Cake\Http\Session $session Session instance.
-     *
      * @return \Cake\Datasource\EntityInterface|null User array or entity
      *   on success, null on failure.
      */
@@ -353,7 +348,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      * @param \SocialConnect\Common\Entity\User $identity Social connect entity.
      * @param \SocialConnect\Provider\AccessTokenInterface $accessToken Access token
      * @param \Cake\Datasource\EntityInterface $profile Social profile entity
-     *
      * @return \Cake\Datasource\EntityInterface
      */
     protected function _patchProfile(
@@ -415,7 +409,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      *
      * @param \Cake\Datasource\EntityInterface $profile Social profile entity.
      * @param \Cake\Http\Session $session Session instance.
-     *
      * @return \Cake\Datasource\EntityInterface User entity.
      */
     protected function _getUserEntity(EntityInterface $profile, $session): EntityInterface
@@ -435,9 +428,7 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      * Save social profile entity.
      *
      * @param \Cake\Datasource\EntityInterface $profile Social profile entity.
-     *
      * @throws \RuntimeException Thrown when unable to save social profile.
-     *
      * @return void
      */
     protected function _saveProfile(EntityInterface $profile): void
@@ -451,7 +442,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      * Get social connect service instance.
      *
      * @param \Cake\Http\ServerRequest $request Request instance.
-     *
      * @return \SocialConnect\Auth\Service
      */
     protected function _getService(ServerRequest $request): Service
@@ -496,7 +486,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      * Save URL to redirect to after authentication to session.
      *
      * @param \Cake\Http\ServerRequest $request Request instance.
-     *
      * @return void
      */
     protected function _setRedirectUrl(ServerRequest $request): void
@@ -520,7 +509,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      * Get URL to redirect to after authentication.
      *
      * @param \Cake\Http\ServerRequest $request Request instance.
-     *
      * @return string|array
      */
     protected function _getRedirectUrl(ServerRequest $request)
@@ -540,7 +528,6 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      *
      * @param \Psr\Http\Message\ServerRequestInterface $request The current request.
      * @param \Exception $exception The exception to log a message for.
-     *
      * @return string Error message
      */
     protected function _getLogMessage($request, $exception): string
@@ -559,7 +546,8 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
         }
 
         if ($exception instanceof InvalidResponse && $exception->getResponse()) {
-            $message .= "\nProvider Response: " . $exception->getResponse()->getBody();
+            $response = $exception->getResponse();
+            $message .= "\nProvider Response: " . ($response ? $response->getBody() : 'n/a');
         }
 
         $message .= "\nStack Trace:\n" . $exception->getTraceAsString() . "\n\n";

--- a/src/Model/Table/SocialProfilesTable.php
+++ b/src/Model/Table/SocialProfilesTable.php
@@ -27,7 +27,6 @@ use Cake\ORM\Table;
  * @method \ADmad\SocialAuth\Model\Entity\SocialProfile[]|\Cake\Datasource\ResultSetInterface saveManyOrFail(iterable $entities, $options = [])
  * @method \ADmad\SocialAuth\Model\Entity\SocialProfile[]|\Cake\Datasource\ResultSetInterface|false deleteMany(iterable $entities, $options = [])
  * @method \ADmad\SocialAuth\Model\Entity\SocialProfile[]|\Cake\Datasource\ResultSetInterface deleteManyOrFail(iterable $entities, $options = [])
- *
  * @mixin \Cake\ORM\Behavior\TimestampBehavior
  */
 class SocialProfilesTable extends Table
@@ -36,7 +35,6 @@ class SocialProfilesTable extends Table
      * Initialize table.
      *
      * @param array $config Configuration
-     *
      * @return void
      */
     public function initialize(array $config): void
@@ -50,7 +48,6 @@ class SocialProfilesTable extends Table
      * Set custom type of "access_token" column.
      *
      * @param \Cake\Database\Schema\TableSchemaInterface $schema The table definition fetched from database.
-     *
      * @return \Cake\Database\Schema\TableSchemaInterface
      */
     protected function _initializeSchema(TableSchemaInterface $schema): TableSchemaInterface

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -19,8 +19,12 @@ use Cake\Routing\RouteBuilder;
 class Plugin extends BasePlugin
 {
     /**
+     * @var bool
+     */
+    protected $consoleEnabled = false;
+
+    /**
      * @param \Cake\Core\PluginApplicationInterface $app Application instance.
-     *
      * @return void
      */
     public function bootstrap(PluginApplicationInterface $app): void
@@ -30,7 +34,6 @@ class Plugin extends BasePlugin
 
     /**
      * @param \Cake\Routing\RouteBuilder $routes Routes builder instance.
-     *
      * @return void
      */
     public function routes(RouteBuilder $routes): void


### PR DESCRIPTION
I moved the array conversation down so that event and profile can be passed as entities to the callback as I wanted to access virtual fields on the entity.

my callback is now:
```php
    /**
     * @param \Cake\Event\EventInterface $event
     *
     * @return \App\Model\Entity\User
     */
    public function updateUser(EventInterface $event): User
    {
        /** @var \App\Model\Entity\User $user */
        $user = $event->getData()['user'];
        /** @var \ADmad\SocialAuth\Model\Entity\SocialProfile $profile */
        $profile = $event->getData()['profile'];

        // additional mapping operations and save

        $this->saveOrFail($user);

        return $user;
    }
```

which works fine now.