### PR TITLE
Pass also Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Then create such method in this Table class:
      * @param \Cake\Http\Session $session
      * @return \App\Model\Entity\User
      */
-    public function afterIdentify(EventInterface $event, $user, $session)
+    public function afterIdentify(EventInterface $event, User $user, Session $session)
     {
         // You can access the profile through $user->social_profile->...
 
@@ -242,7 +242,7 @@ For successful login and flash you can use the above event and manually write to
      * @param \App\Model\Entity\User $user
      * @param \Cake\Http\Session $session
      *
-     * @return null
+     * @return \App\Model\Entity\User
      */
     public function afterIdentify(EventInterface $event, User $user, Session $session)
     {
@@ -255,7 +255,9 @@ For successful login and flash you can use the above event and manually write to
         ];
         $session->write('Flash.flash', $messages);
 
-        return null;
+        // ... (last_login timestamp update etc)
+
+        return $user;
     }
 ```
 Since we redirect afterwards, we must write to the session here.

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -225,7 +225,8 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
 
         $user->unset($config['fields']['password']);
 
-        $event = $this->dispatchEvent(self::EVENT_AFTER_IDENTIFY, ['user' => $user]);
+        $data = ['user' => $user, 'session' => $request->getSession()];
+        $event = $this->dispatchEvent(self::EVENT_AFTER_IDENTIFY, $data);
         $result = $event->getResult();
         if ($result !== null) {
             $user = $event->getResult();


### PR DESCRIPTION
Tackles the issue of callback now not being able to access controller/component anymore (coming from Hybrid)
https://github.com/ADmad/cakephp-social-auth/issues/70

This way one could manually write the necessary Flash message into the session before redirect
And we wouldn't have to mess with the query string ? success topic.
