### PR TITLE
Do not switch logged-in user

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ class SocialAuthListener implements EventListenerInterface
         ];
     }
 
-    public function beforeIdentify(EventInterface $event, EntityInterface $profile, Session $session): EntityInterface
+    public function beforeIdentify(EventInterface $event, EntityInterface $profile, Session $session)
     {
         // If you do not switch logged-in users
         $userId = $profile->get('user_id');

--- a/README.md
+++ b/README.md
@@ -239,12 +239,27 @@ class SocialAuthListener implements EventListenerInterface
     public function implementedEvents(): array
     {
         return [
+            SocialAuthMiddleware::EVENT_BEFORE_IDENTIFY => 'beforeIdentify',
             SocialAuthMiddleware::EVENT_AFTER_IDENTIFY => 'afterIdentify',
             SocialAuthMiddleware::EVENT_BEFORE_REDIRECT => 'beforeRedirect',
             // Uncomment below if you want to use the event listener to return
             // an entity for a new user instead of directly using `createUser()` table method.
             // SocialAuthMiddleware::EVENT_CREATE_USER => 'createUser',
         ];
+    }
+
+    public function beforeIdentify(EventInterface $event, EntityInterface $profile, Session $session): EntityInterface
+    {
+        // If you do not switch logged-in users
+        $userId = $profile->get('user_id');
+        $sessionUserId = $session->read('Auth.id');
+        if ($userId === null || $sessionUserId === null) {
+            return;
+        }
+ 
+        if ($userId != $sessionUserId) {
+            return __('Linked to other users');
+        }
     }
 
     public function afterIdentify(EventInterface $event, EntityInterface $user): EntityInterface

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ class SocialAuthListener implements EventListenerInterface
         }
  
         if ($userId != $sessionUserId) {
-            return __('Linked to other users');
+            return false;
         }
     }
 
@@ -307,6 +307,15 @@ class SocialAuthListener implements EventListenerInterface
             case SocialAuthMiddleware::AUTH_STATUS_FINDER_FAILURE:
                 $messages[] = [
                     'message' => __('Authentication failed'),
+                    'key' => 'flash',
+                    'element' => 'flash/error',
+                    'params' => [],
+                ];
+                break;
+
+            case SocialAuthMiddleware::AUTH_STATUS_IDENTIFY_FAILURE:
+                $messages[] = [
+                    'message' => __('Linked to other user'),
                     'key' => 'flash',
                     'element' => 'flash/error',
                     'params' => [],

--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Event\EventListenerInterface;
 use Cake\Http\ServerRequest;
+use Cake\Http\Session;
 use Cake\I18n\FrozenTime;
 use Cake\ORM\Locator\LocatorAwareTrait;
 

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -55,6 +55,13 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
     public const QUERY_STRING_REDIRECT = 'redirect';
 
     /**
+     * The name of the event that is fired before user identification.
+     *
+     * @var string
+     */
+    public const EVENT_BEFORE_IDENTIFY = 'SocialAuth.beforeIdentify';
+
+    /**
      * The name of the event that is fired for a new user.
      *
      * @var string
@@ -95,6 +102,13 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      * @var string
      */
     public const AUTH_STATUS_FINDER_FAILURE = 'finder_failure';
+
+    /**
+     * Auth identify failure status.
+     *
+     * @var string
+     */
+    public const AUTH_STATUS_IDENTIFY_FAILURE = 'identify_failure';
 
     /**
      * Default config.
@@ -359,6 +373,17 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
      */
     protected function _getUser(EntityInterface $profile, CakeSession $session): ?EntityInterface
     {
+        $event = $this->dispatchEvent(self::EVENT_BEFORE_IDENTIFY, [
+            'profile' => $profile,
+            'session' => $session,
+        ]);
+        $result = $event->getResult();
+        if ($result !== null) {
+            $this->_error = is_string($result) ? $result : self::AUTH_STATUS_IDENTIFY_FAILURE;
+
+            return null;
+        }
+
         $user = null;
 
         /** @var string $userPkField */

--- a/src/Middleware/SocialAuthMiddleware.php
+++ b/src/Middleware/SocialAuthMiddleware.php
@@ -379,7 +379,7 @@ class SocialAuthMiddleware implements MiddlewareInterface, EventDispatcherInterf
         ]);
         $result = $event->getResult();
         if ($result !== null) {
-            $this->_error = is_string($result) ? $result : self::AUTH_STATUS_IDENTIFY_FAILURE;
+            $this->_error = self::AUTH_STATUS_IDENTIFY_FAILURE;
 
             return null;
         }


### PR DESCRIPTION
I want to make an error when the logged-in user and the user specified by social login are different.

---


I can add social login to logged-in users.
If another user is already linked, make an error instead of switching the logged-in user.
```
echo $this->Form->postLink(
    'Link to Facebook',
    [
        'prefix' => false,
        'plugin' => 'ADmad/SocialAuth',
        'controller' => 'Auth',
        'action' => 'login',
        'provider' => 'facebook',
        '?' => ['redirect' => $this->Html->url()]
    ]
);
```