### PR TITLE
Prevent logged in user override.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         php-version: '7.4'
         extensions: mbstring, intl
         coverage: none
-        tools: cs2pr, psalm:^4.7, phpstan:^0.12
+        tools: cs2pr, psalm:4.7, phpstan:0.12
 
     - name: Composer Install
       run: composer install

--- a/README.md
+++ b/README.md
@@ -268,17 +268,10 @@ class SocialAuthListener implements EventListenerInterface
      */
     public function beforeRedirect(EventInterface $event, $url, string $status, ServerRequest $request): void
     {
-        $messages = (array)$request->getSession()->read('Flash.flash');
-
         // Set flash message
         switch ($status) {
             case SocialAuthMiddleware::AUTH_STATUS_SUCCESS:
-                $messages[] = [
-                    'message' => __('You are now logged in'),
-                    'key' => 'flash',
-                    'element' => 'flash/success',
-                    'params' => [],
-                ];
+                $request->getFlash()->error('You are now logged in.');
                 break;
 
             // Auth through provider failed. Details will be logged in
@@ -289,16 +282,13 @@ class SocialAuthListener implements EventListenerInterface
             // user has been authenticated through provider but your finder has
             // a condition to not return an inactivated user.
             case SocialAuthMiddleware::AUTH_STATUS_FINDER_FAILURE:
-                $messages[] = [
-                    'message' => __('Authentication failed'),
-                    'key' => 'flash',
-                    'element' => 'flash/error',
-                    'params' => [],
-                ];
+                $request->getFlash()->error('Authentication failed.');
+                break;
+
+            case SocialAuthMiddleware::AUTH_STATUS_IDENTITY_MISMATCH:
+                $request->getFlash()->error('The social profile is already linked to another user.');
                 break;
         }
-
-        $request->getSession()->write('Flash.flash', $messages);
 
         // You can return a modified redirect URL if needed.
     }

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace ADmad\SocialAuth\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * UsersFixture
+ */
+class UsersFixture extends TestFixture
+{
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // phpcs:disable
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'email' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'collate' => 'utf8mb4_unicode_ci', 'comment' => '', 'precision' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8mb4_unicode_ci'
+        ],
+    ];
+    // phpcs:enable
+
+    /**
+     * Init method
+     *
+     * @return void
+     */
+    public function init(): void
+    {
+        $this->records = [];
+
+        parent::init();
+    }
+}

--- a/tests/TestCase/Middleware/SocialAuthMiddlewareTest.php
+++ b/tests/TestCase/Middleware/SocialAuthMiddlewareTest.php
@@ -4,10 +4,16 @@ declare(strict_types=1);
 namespace ADmad\SocialAuth\Test\TestCase\Middleware;
 
 use ADmad\SocialAuth\Middleware\SocialAuthMiddleware;
+use ADmad\SocialAuth\Model\Entity\SocialProfile;
+use ADmad\SocialAuth\Model\Table\SocialProfilesTable;
+use Cake\Event\EventInterface;
+use Cake\Event\EventManager;
 use Cake\Http\Exception\MethodNotAllowedException;
 use Cake\Http\Response;
 use Cake\Http\ServerRequestFactory;
 use Cake\TestSuite\TestCase;
+use SocialConnect\Common\Entity\User;
+use SocialConnect\Provider\AccessTokenInterface;
 use SocialConnect\Provider\Session\Dummy;
 use TestApp\Http\TestRequestHandler;
 
@@ -17,6 +23,11 @@ use TestApp\Http\TestRequestHandler;
  */
 class SocialAuthMiddlewareTest extends TestCase
 {
+    protected $fixtures = [
+        'plugin.ADmad/SocialAuth.Users',
+        'plugin.ADmad/SocialAuth.SocialProfiles',
+    ];
+
     public function setUp(): void
     {
         parent::setUp();
@@ -95,6 +106,61 @@ class SocialAuthMiddlewareTest extends TestCase
         $this->expectException($class);
 
         $middleware = new SocialAuthMiddleware();
+        $middleware->process($request, $this->handler);
+    }
+
+    /**
+     * Test that IDENTITY_MISMATCH_ERROR occurs when a social profile is already
+     * associated with a user and that user does not match the user record set
+     * in the session.
+     *
+     * @return void
+     * @see https://github.com/ADmad/cakephp-social-auth/pull/108
+     */
+    public function testIdentityMismatchError()
+    {
+        $request = ServerRequestFactory::fromGlobals([
+            'REQUEST_URI' => '/social-auth/callback/facebook',
+        ]);
+        $request = $request->withAttribute('params', [
+            'plugin' => 'ADmad/SocialAuth',
+            'controller' => 'Auth',
+            'action' => 'callback',
+            'provider' => 'facebook',
+        ]);
+        $request->getSession()->write('Auth', ['id' => 1]);
+
+        $this->getTableLocator()->get(SocialProfilesTable::class)
+            ->save(new SocialProfile([
+                'user_id' => 2,
+                'provider' => 'facebook',
+                'identifier' => 'fbid',
+                'email' => 'fb@fb.test',
+                'access_token' => '',
+            ]));
+
+        $middleware = $this->getMockBuilder(SocialAuthMiddleware::class)
+            ->onlyMethods(['_getSocialIdentity'])
+            ->getMock();
+
+        $accessToken = $this->getMockBuilder(AccessTokenInterface::class)
+            ->getMock();
+
+        $identity = new User();
+        $identity->id = 'fbid';
+        $identity->email = 'fb@fb.test';
+
+        $middleware->expects($this->once())
+            ->method('_getSocialIdentity')
+            ->willReturn(['identity' => $identity, 'access_token' => $accessToken]);
+
+        EventManager::instance()->on(
+            SocialAuthMiddleware::EVENT_BEFORE_REDIRECT,
+            function (EventInterface $event, $url, string $status) {
+                $this->assertSame(SocialAuthMiddleware::AUTH_STATUS_IDENTITY_MISMATCH, $status);
+            }
+        );
+
         $middleware->process($request, $this->handler);
     }
 }


### PR DESCRIPTION
If social profile is already associated with a user and it mismatches
with user record in session (if set) then abort the login instead of
overwritting the user record in session.

Also the session id is now renewed when user record is written to session.

Closes #108.