### PR TITLE
Use BaseMigration instead of deprecated AbstractMigration

### DIFF
--- a/config/Migrations/20190914000000_CreateSocialProfiles.php
+++ b/config/Migrations/20190914000000_CreateSocialProfiles.php
@@ -1,7 +1,7 @@
 <?php
-use Phinx\Migration\AbstractMigration;
+use Migrations\BaseMigration;
 
-class CreateSocialProfiles extends AbstractMigration
+class CreateSocialProfiles extends BaseMigration
 {
     public function change()
     {


### PR DESCRIPTION
## Summary

- Update migration to use `Migrations\BaseMigration` instead of the deprecated `Phinx\Migration\AbstractMigration` class


This currently blocks me upgrading to 5.x of migrations.